### PR TITLE
bugfix/hardcoded-energy-query

### DIFF
--- a/dashboard_ui/config/dashboards/Power Monitoring/dashboard_20A_3P.json
+++ b/dashboard_ui/config/dashboards/Power Monitoring/dashboard_20A_3P.json
@@ -349,7 +349,7 @@
             "type": "influxdb",
             "uid": "influxdb"
           },
-          "query": "from(bucket: \"power_monitoring\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"equipment_power_usage\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"power\")\r\n  |> filter(fn: (r) => r[\"machine\"] == \"Machine_1\")\r\n  |> integral()\r\n  |> map(fn: (r) => ({r with _value: r._value / float(v: int(v:1h)/int(v: 1s))}))",
+          "query": "from(bucket: \"power_monitoring\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"equipment_power_usage\")\r\n  |> filter(fn: (r) => r[\"_field\"] == \"power\")\r\n  |> filter(fn: (r) => r[\"machine\"] == \"${machine}\")\r\n  |> integral()\r\n  |> map(fn: (r) => ({r with _value: r._value / float(v: int(v:1h)/int(v: 1s))}))",
           "refId": "A"
         }
       ],


### PR DESCRIPTION
Fixes #11 

flux query uses grafana global variable for machine name instead of hardcoded string